### PR TITLE
增加GBK和UTF8的识别

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,4 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+/.vs

--- a/novelReader/Models/NovelFile.cs
+++ b/novelReader/Models/NovelFile.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -14,23 +14,45 @@ namespace novelReader.Models
         {
             if (String.IsNullOrEmpty(path))
             {
-                return ;
+                return;
             }
 
-            using (FileStream fs = File.Open(path, FileMode.Open, FileAccess.Read))
-            using (BufferedStream bs = new BufferedStream(fs))
-            using (StreamReader sr = new StreamReader(bs, Encoding.Default))
-            {
-                String line;
+            FileStream fs = File.Open(path, FileMode.Open, FileAccess.Read);
 
-                while ((line = sr.ReadLine()) != null)
+            StreamReader sr = new StreamReader(fs);
+            if (sr.CurrentEncoding == Encoding.UTF8)
+            {
+                var chArr = new char[1024];
+                sr.Read(chArr, 0, chArr.Length);
+                var buffer1 = Encoding.UTF8.GetBytes(chArr);
+                var buffer2 = new byte[buffer1.Length];
+                fs.Position = 0;
+                fs.Read(buffer2, 0, buffer2.Length);
+                var same = true;
+                for (int i = 0; i < buffer1.Length; i++)
                 {
-                    if (!String.IsNullOrWhiteSpace(line))
+                    if (buffer1[i] != buffer2[i])
                     {
-                        novel.Add(new Content(line));
+                        same = false;
+                        break;
                     }
                 }
+                if (!same)
+                {
+                    fs.Position = 0;
+                    sr = new StreamReader(fs, Encoding.GetEncoding("GBK"));
+                }
             }
+            String line;
+
+            while ((line = sr.ReadLine()) != null)
+            {
+                if (!String.IsNullOrWhiteSpace(line))
+                {
+                    novel.Add(new Content(line));
+                }
+            }
+            sr.Dispose();
         }
     }
 }

--- a/novelReader/novelReader.csproj
+++ b/novelReader/novelReader.csproj
@@ -69,7 +69,7 @@
     <GenerateManifests>true</GenerateManifests>
   </PropertyGroup>
   <PropertyGroup>
-    <SignManifests>true</SignManifests>
+    <SignManifests>false</SignManifests>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -132,7 +132,6 @@
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="novelReader_TemporaryKey.pfx" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>


### PR DESCRIPTION
StreamReader可以自动识别有BOM头的UTF8文本。当StreamReader为UTF8时，有可能是GBK，所以用StreamReader默认的方式读取1K的Char，再转为byte，与FileStream流比较。如果一样，则是没有BOM头的UTF8文本。如果不一样，就将StreamReader编码方式设成GBK。